### PR TITLE
fix: replace broken links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JpegTurbo
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://johnnychen94.github.io/JpegTurbo.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://johnnychen94.github.io/JpegTurbo.jl/dev)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaio.github.io/JpegTurbo.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaio.github.io/JpegTurbo.jl/dev)
 [![Build Status](https://github.com/johnnychen94/JpegTurbo.jl/actions/workflows/UnitTest.yml/badge.svg?branch=master)](https://github.com/johnnychen94/JpegTurbo.jl/actions/workflows/UnitTest.yml?query=branch%3Amaster)
 [![Coverage](https://codecov.io/gh/johnnychen94/JpegTurbo.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/johnnychen94/JpegTurbo.jl)
 


### PR DESCRIPTION
The two URL links to the documentation in the badges in README.md are replaced by currently available URLs.