### PR TITLE
Add Aqua compat, remove project_toml_formatting setting

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,3 +7,6 @@ ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
+
+[compat]
+Aqua = "0.8"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,6 @@ include("testutils.jl")
                 project_extras=true,
                 deps_compat=true,
                 stale_deps=true,
-                project_toml_formatting=true
             )
             doctest(JpegTurbo, manual = false)
         end


### PR DESCRIPTION
Removal of `project_toml_formatting` was a breaking change for Aqua v0.8, see https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.0.